### PR TITLE
feat(cli:context): add support for Schema Registry context management

### DIFF
--- a/cli/context/pom.xml
+++ b/cli/context/pom.xml
@@ -71,13 +71,24 @@
             <version>${kafka.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>7.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.36</version>
         </dependency>
+
         <dependency>
             <groupId>io.github.jeqo.kafka</groupId>
             <artifactId>kafka-clients-graalvm</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.jeqo.kafka</groupId>
+            <artifactId>schema-registry-client-graalvm</artifactId>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
@@ -276,9 +287,11 @@
                             <buildArgs>
                                 <buildArg>--no-fallback</buildArg>
                                 <buildArg>--allow-incomplete-classpath</buildArg>
+                                <buildArg>--enable-url-protocols=http</buildArg>
+                                <buildArg>--enable-url-protocols=https</buildArg>
                                 <buildArg>-H:AdditionalSecurityProviders=com.sun.security.sasl.Provider</buildArg>
                                 <buildArg>--initialize-at-run-time=org.apache.kafka.common.security.authenticator.SaslClientAuthenticator</buildArg>
-                                <buildArg>--initialize-at-build-time=org.slf4j.LoggerFactory,org.slf4j.impl.StaticLoggerBinder,org.slf4j.impl.SimpleLogger,org.apache.kafka,kafka,com.fasterxml.jackson,jdk.xml,javax.xml,com.sun.org.apache.xerces</buildArg>
+                                <buildArg>--initialize-at-build-time=org.slf4j.LoggerFactory,org.slf4j.impl.StaticLoggerBinder,org.slf4j.impl.SimpleLogger,org.apache.kafka,kafka,com.fasterxml.jackson,jdk.xml,javax.xml,com.sun.org.apache.xerces,org.yaml.snakeyaml</buildArg>
                                 <buildArg>-H:ReflectionConfigurationFiles=../src/main/resources/META-INF/native-image/io.github.jeqo.kafka/kafka-clis/reflect-kafka-client.json</buildArg>
                                 <buildArg>-H:Log=registerResource:3</buildArg>
                                 <buildArg>-H:ResourceConfigurationFiles=../src/main/resources/META-INF/native-image/io.github.jeqo.kafka/kafka-clis/resource-config.json</buildArg>

--- a/cli/context/pom.xml
+++ b/cli/context/pom.xml
@@ -71,11 +71,6 @@
             <version>${kafka.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
-            <version>7.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.36</version>
@@ -84,11 +79,6 @@
         <dependency>
             <groupId>io.github.jeqo.kafka</groupId>
             <artifactId>kafka-clients-graalvm</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>io.github.jeqo.kafka</groupId>
-            <artifactId>schema-registry-client-graalvm</artifactId>
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/cli/context/src/main/java/kafka/cli/context/Cli.java
+++ b/cli/context/src/main/java/kafka/cli/context/Cli.java
@@ -1,5 +1,19 @@
 package kafka.cli.context;
 
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Optional;
+import kafka.cli.context.Cli.SchemaRegistryContextsCommand;
+import kafka.cli.context.KafkaContexts.KafkaContext;
+import kafka.cli.context.SchemaRegistryContexts.SchemaRegistryAuth;
+import kafka.cli.context.SchemaRegistryContexts.SchemaRegistryCluster;
+import kafka.cli.context.SchemaRegistryContexts.SchemaRegistryContext;
+import kafka.cli.context.SchemaRegistryContexts.UsernamePasswordAuth;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import picocli.CommandLine;
 
@@ -8,10 +22,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
 
 @CommandLine.Command(name = "kfk-ctx", versionProvider = Cli.VersionProviderWithConfigProvider.class, mixinStandardHelpOptions = true, subcommands = {
         Cli.Create.class,
-        Cli.ConfigProperties.class }, descriptionHeading = "Kafka CLI - Context", description = "Manage Kafka connection properties as contexts.")
+        Cli.ConfigProperties.class,
+        SchemaRegistryContextsCommand.class }, descriptionHeading = "Kafka CLI - Context", description = "Manage Kafka connection properties as contexts.")
 public class Cli implements Callable<Integer> {
 
     public static void main(String[] args) {
@@ -21,22 +38,38 @@ public class Cli implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        var contexts = Contexts.from(Files.readAllBytes(contextConfig()));
+        var contexts = KafkaContexts.from(Files.readAllBytes(kafkaContextConfig()));
         System.out.println(contexts.names());
         return 0;
     }
 
-    static void save(Contexts contexts) throws IOException {
-        Files.write(contextConfig(), contexts.serialize());
+    static void save(KafkaContexts contexts) throws IOException {
+        Files.write(kafkaContextConfig(), contexts.serialize());
     }
 
-    static Path contextConfig() throws IOException {
+    static void save(SchemaRegistryContexts contexts) throws IOException {
+        Files.write(schemaRegistryContextConfig(), contexts.serialize());
+    }
+
+    static Path kafkaContextConfig() throws IOException {
         final Path home = baseDir();
 
-        final var context = home.resolve("config");
+        final var context = home.resolve("kafka.json");
         if (!Files.isRegularFile(context)) {
             System.err.println("Kafka Content configuration file doesn't exist, creating one...");
-            Files.write(context, Contexts.empty());
+            Files.write(context, KafkaContexts.empty());
+        }
+
+        return context;
+    }
+
+    static Path schemaRegistryContextConfig() throws IOException {
+        final Path home = baseDir();
+
+        final var context = home.resolve("schema-registry.json");
+        if (!Files.isRegularFile(context)) {
+            System.err.println("Schema Registry Content configuration file doesn't exist, creating one...");
+            Files.write(context, KafkaContexts.empty());
         }
 
         return context;
@@ -44,8 +77,9 @@ public class Cli implements Callable<Integer> {
 
     private static Path baseDir() throws IOException {
         final var homePath = System.getProperty("user.home");
-        if (homePath.isBlank())
+        if (homePath.isBlank()) {
             throw new IllegalStateException("Can't find user's home. ${HOME} is empty");
+        }
 
         final var home = Path.of(homePath, ".kafka");
         if (!Files.isDirectory(home)) {
@@ -55,7 +89,7 @@ public class Cli implements Callable<Integer> {
         return home;
     }
 
-    @CommandLine.Command(name = "create", description = "Register context. Destination: ~/.kafka/config")
+    @CommandLine.Command(name = "create", description = "Register context. Destination: ~/.kafka/kafka.json")
     static class Create implements Callable<Integer> {
 
         @CommandLine.Parameters(index = "0", description = "Context name. e.g. `local`")
@@ -64,23 +98,23 @@ public class Cli implements Callable<Integer> {
         String bootstrapServers;
 
         @CommandLine.Option(names = "--auth", description = "Authentication type (default: ${DEFAULT-VALUE}). Valid values: ${COMPLETION-CANDIDATES}", required = true, defaultValue = "PLAINTEXT")
-        Contexts.KafkaAuth.AuthType authType;
-        @CommandLine.Option(names = { "--username", "-u" }, description = "Username for SASL authentication")
-        String username;
-        @CommandLine.Option(names = { "--password", "-p" }, description = "Password for SASL authentication", arity = "0..1", interactive = true)
-        String password;
+        KafkaContexts.KafkaAuth.AuthType authType;
+
+        @ArgGroup(exclusive = false)
+        UsernamePasswordOptions usernamePasswordOptions;
 
         @Override
         public Integer call() throws Exception {
-            var contexts = Contexts.from(Files.readAllBytes(contextConfig()));
+            var contexts = KafkaContexts.from(Files.readAllBytes(kafkaContextConfig()));
 
-            final Contexts.KafkaAuth auth;
-            switch (authType) {
-                case SASL_PLAIN -> auth = new Contexts.UsernamePasswordAuth(authType, username,
-                        passwordHelper().encrypt(password));
-                default -> auth = new Contexts.NoAuth();
-            }
-            final var ctx = new Contexts.Context(name, new Contexts.KafkaCluster(bootstrapServers, auth));
+            final KafkaContexts.KafkaAuth auth = switch (authType) {
+                case SASL_PLAIN -> new KafkaContexts.UsernamePasswordAuth(
+                        authType,
+                        usernamePasswordOptions.username,
+                        passwordHelper().encrypt(usernamePasswordOptions.password));
+                default -> new KafkaContexts.NoAuth();
+            };
+            final var ctx = new KafkaContext(name, new KafkaContexts.KafkaCluster(bootstrapServers, auth));
 
             contexts.add(ctx);
             save(contexts);
@@ -89,7 +123,6 @@ public class Cli implements Callable<Integer> {
                     ctx.cluster().bootstrapServers());
             return 0;
         }
-
     }
 
     static PasswordHelper passwordHelper() throws IOException {
@@ -110,20 +143,24 @@ public class Cli implements Callable<Integer> {
 
         @CommandLine.Parameters(index = "0", description = "Context name")
         String name;
+
         @CommandLine.Option(names = { "--test", "-t" }, description = "Test properties")
         boolean test;
 
+        @Option(names = { "--schema-registry", "-sr" }, description = "Schema Registry context name")
+        Optional<String> schemeRegistryContext;
+
         @Override
         public Integer call() throws Exception {
-            var contexts = Contexts.from(Files.readAllBytes(contextConfig()));
-            var ctx = contexts.get(name);
-            final Properties props = ctx.properties(passwordHelper());
-            props.store(System.out, "Generated by kfkctx");
+            final var contexts = KafkaContexts.from(Files.readAllBytes(kafkaContextConfig()));
+            final var ctx = contexts.get(name);
+            final var props = ctx.properties(passwordHelper());
+            props.store(System.out, "Kafka client properties generated by kfk-ctx");
 
             if (test) {
                 try (final var admin = AdminClient.create(props)) {
                     final var clusterId = admin.describeCluster().clusterId().get();
-                    System.err.printf("Connection to cluster %s succeed%n", clusterId);
+                    System.err.printf("Connection to cluster %s (id=%s) succeed%n", props.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG), clusterId);
                     admin.describeCluster().nodes().get().forEach(node -> System.err.println("Node: " + node));
                 }
                 catch (Exception e) {
@@ -131,10 +168,107 @@ public class Cli implements Callable<Integer> {
                     e.printStackTrace();
                     return 1;
                 }
+
+            }
+
+            if (schemeRegistryContext.isPresent()) {
+                final var srContexts = SchemaRegistryContexts.from(Files.readAllBytes(schemaRegistryContextConfig()));
+                if (srContexts.has(schemeRegistryContext.get())) {
+                    final var srCtx = srContexts.get(schemeRegistryContext.get());
+                    final var srProps = srCtx.properties(passwordHelper());
+
+                    srProps.store(System.out, "Schema Registry client properties generated by kfk-ctx");
+
+                    if (test) {
+                        final var auth = srCtx.cluster().auth();
+                        final var httpClient = switch (auth.type()) {
+                            case BASIC_AUTH -> HttpClient.newBuilder()
+                                    .authenticator(new Authenticator() {
+                                        @Override
+                                        protected PasswordAuthentication getPasswordAuthentication() {
+                                            final var basicAuth = (UsernamePasswordAuth) auth;
+                                            return new PasswordAuthentication(basicAuth.username(), basicAuth.password().toCharArray());
+                                        }
+                                    })
+                                    .build();
+                            case NO_AUTH -> HttpClient.newHttpClient();
+                        };
+                        final var urls = srCtx.cluster().urls();
+                        final var response = httpClient.send(HttpRequest.newBuilder()
+                                .uri(URI.create(urls))
+                                .GET()
+                                .build(),
+                                BodyHandlers.discarding());
+                        if (response.statusCode() == 200) {
+                            System.err.printf("Connection to schema registry cluster %s succeed%n", urls);
+                        }
+                        else {
+                            System.err.printf("Connection to schema registry cluster %s failed%n", urls);
+                            return 1;
+                        }
+                    }
+                }
+                else {
+                    System.err.printf("WARN: Schema Registry context %s does not exist. Schema Registry connection properties will not be included",
+                            schemeRegistryContext.get());
+                }
             }
             return 0;
         }
 
+    }
+
+    @CommandLine.Command(name = "sr", subcommands = {
+            SchemaRegistryContextsCommand.Create.class }, description = "Manage Schema Registry connection properties as contexts.")
+    static class SchemaRegistryContextsCommand implements Callable<Integer> {
+        @Override
+        public Integer call() throws Exception {
+            var contexts = SchemaRegistryContexts.from(Files.readAllBytes(schemaRegistryContextConfig()));
+            System.out.println(contexts.names());
+            return 0;
+        }
+
+        @CommandLine.Command(name = "create", description = "Register context. Destination: ~/.kafka/schema-registry.json")
+        static class Create implements Callable<Integer> {
+
+            @CommandLine.Parameters(index = "0", description = "Context name. e.g. `local`")
+            String name;
+            @CommandLine.Parameters(index = "1", description = "Schema Registry URLs. e.g. `http://localhost:8081`")
+            String urls;
+
+            @CommandLine.Option(names = "--auth", description = "Authentication type (default: ${DEFAULT-VALUE}). Valid values: ${COMPLETION-CANDIDATES}", required = true, defaultValue = "PLAINTEXT")
+            SchemaRegistryAuth.AuthType authType;
+
+            @ArgGroup(exclusive = false)
+            UsernamePasswordOptions usernamePasswordOptions;
+
+            @Override
+            public Integer call() throws Exception {
+                var contexts = SchemaRegistryContexts.from(Files.readAllBytes(schemaRegistryContextConfig()));
+
+                final SchemaRegistryAuth auth;
+                switch (authType) {
+                    case BASIC_AUTH -> auth = new SchemaRegistryContexts.UsernamePasswordAuth(authType, usernamePasswordOptions.username,
+                            passwordHelper().encrypt(usernamePasswordOptions.password));
+                    default -> auth = new SchemaRegistryContexts.NoAuth();
+                }
+                final var ctx = new SchemaRegistryContext(name, new SchemaRegistryCluster(urls, auth));
+
+                contexts.add(ctx);
+                save(contexts);
+
+                System.out.printf("Context %s with URLs %s saved.", ctx.name(),
+                        ctx.cluster().urls());
+                return 0;
+            }
+        }
+    }
+
+    static class UsernamePasswordOptions {
+        @CommandLine.Option(names = { "--username", "-u" }, description = "Username authentication")
+        String username;
+        @CommandLine.Option(names = { "--password", "-p" }, description = "Password authentication", arity = "0..1", interactive = true)
+        String password;
     }
 
     static class VersionProviderWithConfigProvider implements CommandLine.IVersionProvider {

--- a/cli/context/src/main/java/kafka/cli/context/KafkaContexts.java
+++ b/cli/context/src/main/java/kafka/cli/context/KafkaContexts.java
@@ -1,0 +1,149 @@
+package kafka.cli.context;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.plain.internals.PlainSaslServer;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public record KafkaContexts(Map<String, KafkaContext> contextMap) {
+    static final ObjectMapper json = new ObjectMapper();
+
+    static byte[] empty() throws JsonProcessingException {
+        return json.writeValueAsBytes(json.createArrayNode());
+    }
+
+    static KafkaContexts from(byte[] bytes) throws IOException {
+        final var tree = json.readTree(bytes);
+        if (!tree.isArray())
+            throw new IllegalArgumentException("JSON is not an array");
+
+
+        final var array = (ArrayNode) tree;
+        final var contexts = new HashMap<String, KafkaContext>(array.size());
+        for (final var node : array) {
+            final var context = KafkaContext.parse(node);
+            contexts.put(context.name(), context);
+        }
+
+        return new KafkaContexts(contexts);
+    }
+
+    public Set<String> names() {
+        return contextMap.keySet();
+    }
+
+    public byte[] serialize() throws JsonProcessingException {
+        final var array = json.createArrayNode();
+        for (final var ctx : contextMap.values())
+            array.add(ctx.toJson());
+        return json.writeValueAsBytes(array);
+    }
+
+    public void add(KafkaContext ctx) {
+        contextMap.put(ctx.name, ctx);
+    }
+
+    public KafkaContext get(String name) {
+        return contextMap.get(name);
+    }
+
+    record KafkaContext(String name, KafkaCluster cluster) {
+
+        static KafkaContext parse(JsonNode node) {
+            final var name = node.get("name").textValue();
+            return new KafkaContext(name, KafkaCluster.parse(node.get("cluster")));
+        }
+
+        public JsonNode toJson() {
+            final var node = json.createObjectNode().put("name", this.name);
+            node.set("cluster", cluster.toJson());
+            return node;
+        }
+
+        public Properties properties(PasswordHelper passwordHelper) throws IOException {
+            final var props = new Properties();
+            props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                cluster.bootstrapServers());
+            switch (cluster.auth().type()) {
+                case SASL_PLAIN -> {
+                    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+                        SecurityProtocol.SASL_SSL.name);
+                    props.put(SaslConfigs.SASL_MECHANISM, PlainSaslServer.PLAIN_MECHANISM);
+                    var auth = (KafkaContexts.UsernamePasswordAuth) cluster.auth();
+                    props.setProperty(SaslConfigs.SASL_JAAS_CONFIG,
+                        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"%s\" password=\"%s\";".formatted(
+                            auth.username(), passwordHelper.decrypt(auth.password())));
+                }
+                default -> {
+                }
+            }
+            return props;
+        }
+    }
+
+
+    record KafkaCluster(String bootstrapServers, KafkaAuth auth) {
+        static KafkaCluster parse(JsonNode cluster) {
+            return new KafkaCluster(cluster.get("bootstrapServers").textValue(),
+                KafkaAuth.parse(cluster.get("auth")));
+        }
+
+        public JsonNode toJson() {
+            final var node = json.createObjectNode().put("bootstrapServers", bootstrapServers);
+            node.set("auth", auth.toJson());
+            return node;
+        }
+    }
+
+
+    interface KafkaAuth {
+        AuthType type();
+
+        static KafkaAuth parse(JsonNode auth) {
+            final var type = AuthType.valueOf(auth.get("type").textValue());
+            return switch (type) {
+                case SASL_PLAIN -> new UsernamePasswordAuth(type,
+                    auth.get("username").textValue(), auth.get("password").textValue());
+                default -> new NoAuth();
+            };
+        }
+
+        default JsonNode toJson() {
+            return json.createObjectNode().put("type", type().name());
+        }
+
+        enum AuthType {PLAINTEXT, SASL_PLAIN}
+    }
+
+
+    record NoAuth() implements KafkaAuth {
+        @Override public AuthType type() {
+            return AuthType.PLAINTEXT;
+        }
+    }
+
+
+    record UsernamePasswordAuth(AuthType authType, String username, String password)
+        implements KafkaAuth {
+        @Override public AuthType type() {
+            return authType;
+        }
+
+        @Override public JsonNode toJson() {
+            var node = (ObjectNode) KafkaAuth.super.toJson();
+            return node.put("username", username).put("password", password);
+        }
+    }
+
+}

--- a/cli/context/src/main/java/kafka/cli/context/SchemaRegistryContexts.java
+++ b/cli/context/src/main/java/kafka/cli/context/SchemaRegistryContexts.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -70,11 +68,11 @@ public record SchemaRegistryContexts(Map<String, SchemaRegistryContext> contextM
 
         public Properties properties(PasswordHelper passwordHelper) {
             final var props = new Properties();
-            props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+            props.put("schema.registry.url",
                 cluster.urls());
             switch (cluster.auth().type()) {
                 case BASIC_AUTH -> {
-                    props.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+                    props.put("basic.auth.credentials.source", "USER_INFO");
                     var auth = (SchemaRegistryContexts.UsernamePasswordAuth) cluster.auth();
                     props.put("basic.auth.user.info",
                         "%s:%s".formatted(auth.username(), passwordHelper.decrypt(auth.password())));


### PR DESCRIPTION
Manage Schema Registry contexts:

```
$ kfk-ctx sr
[ccloud]
$ kfk-ctx
[ccloud]
$ kfk-ctx properties ccloud -sr ccloud
#Kafka client properties generated by kfk-ctx
#Wed Mar 23 20:00:40 GMT 2022
security.protocol=SASL_SSL
sasl.mechanism=PLAIN
sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username\="..." password\="...";
bootstrap.servers=pkc-....eu-west-1.cp.confluent.cloud\:9092
#Schema Registry client properties generated by kfk-ctx
#Wed Mar 23 20:00:40 GMT 2022
schema.registry.url=https\://psrc-....westeurope.cp.confluent.cloud
basic.auth.user.info=...\:...
basic.auth.credentials.source=USER_INFO
```